### PR TITLE
fix: Routing handlers not working according to declaration order when declaring controller methods

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -17,6 +17,13 @@ export const makeParamBasedCacheKey = (
     ? key
     : paramIndex.reduce((cacheKey, pidx) => `${cacheKey}:${args[pidx]}`, key);
 
+function copyOriginalMetadataToCacheDescriptor(metadataKeys: any[], originalMethod: any, descriptor: PropertyDescriptor) {
+  metadataKeys.forEach((key) => {
+    const metadataValue = Reflect.getMetadata(key, originalMethod);
+    Reflect.defineMetadata(key, metadataValue, descriptor.value);
+  });
+}
+
 export const Cache =
   ({ storage }: { storage: ICacheStorage }) =>
   <Kind extends CacheKind>(cacheOptions: CacheOptions<Kind>) => {
@@ -26,6 +33,7 @@ export const Cache =
       descriptor: PropertyDescriptor
     ) => {
       const originalMethod = descriptor.value;
+      const originalMethodMetadataKeys = Reflect.getMetadataKeys(originalMethod);
       const { key } = cacheOptions;
 
       if (isPersistent(cacheOptions)) {
@@ -42,7 +50,7 @@ export const Cache =
           const result = await originalMethod.call(this);
           storage.set(key, result);
 
-          if (refreshIntervalSec && !(await intervalTimerMap.has(key))) {
+          if (refreshIntervalSec && !(intervalTimerMap.has(key))) {
             setInterval(() => {
               const result = originalMethod.call(this);
 
@@ -107,9 +115,13 @@ export const Cache =
           return result;
         };
       }
+      copyOriginalMetadataToCacheDescriptor(originalMethodMetadataKeys, originalMethod, descriptor);
 
       SetMetadata(CACHE, cacheOptions)(descriptor.value);
 
       return descriptor;
     };
   };
+
+
+

--- a/lib/test/controller.ts
+++ b/lib/test/controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Param, Query } from "@nestjs/common";
 import { sleep, startTime } from "./util";
 import { InMemCache } from "./cache.decorator";
 import { TestService } from "./service";
+import {ModifyMethod} from "../test-decorator";
+import {METHOD_METADATA} from "@nestjs/common/constants";
 
 @Controller()
 export class TestController {
@@ -67,5 +69,16 @@ export class TestController {
     await this.testService.cacheableTask2();
 
     return "test4";
+  }
+
+  @InMemCache({
+    key: "test5",
+    kind: "persistent",
+  })
+  @Get("test5")
+  async reverseOrderDecorator() {
+    await sleep(1000);
+
+    return "test5";
   }
 }

--- a/lib/test/e2e.test.ts
+++ b/lib/test/e2e.test.ts
@@ -137,4 +137,16 @@ describe("e2e test of cache decorator", () => {
     app.close();
     httpServer.close();
   });
+
+  it("should return immediately(set on start).test5 route(decorator order is reversed)", async () => {
+    await sleep(1000);
+
+    const start = Date.now();
+    const response = await request(httpServer).get("/test5");
+    const diff = Date.now() - start;
+
+    equal(response.status, 200);
+    equal(response.text, "test5");
+    lessThan(diff, 50);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rxjs": "7.8.1",
     "supertest": "6.3.3",
     "ts-jest": "29.1.1",
+    "ts-node": "^10.9.2",
     "typescript": "5.3.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
### 개선 사항(Improvements)
- (KR)컨트롤러 메서드 바로 위에 `@InMemCache` 데코레이터가 선언 되었을 경우에만 라우팅 핸들러가 정상 동작하고, 그렇지 않을 경우에는 라우팅 핸들러가 동작하지 않는 문제를 해결하였습니다.
- 또한 이를 검증할 수 있는 간단한 컨트롤러 메서드 하나와 테스트 코드를 추가하였습니다.
- (EN) Fixed an issue where the routing handler would only work correctly if the `@InMemCache` decorator was declared directly above the controller method, otherwise the routing handler would not work.
- (EN) I've also added one simple controller method and test code to validate this.

### 해결 방법(Solution)
- (KR) `cache.ts`에서 `descriptor.value` 를 재정의 하는 과정에서 라우팅에 대한 메타데이터가 함께 재정의 되지 않기 때문에 발생한 문제임을 확인하였습니다.
- (KR) 이를 해결하기 위해 `descriptor.value` 재정의 전 원본 메서드의 메타데이터의 키 값을 미리 저장해두고, 재정의 전에 이 키에 해당하는 메타데이터 정보들을 `descriptor.value`의 메타데이터에 다시 정의해주어 라우팅 핸들러가 동작할 수 있도록 하였습니다.
- (EN) I confirmed that the problem was caused by overriding `descriptor.value` in `cache.ts` and not overriding the metadata for routing together.
- (EN) To solve this, I saved the key value of the metadata of the original method before overriding `descriptor.value`, and redefined the metadata information corresponding to this key in the metadata of `descriptor.value` before overriding, so that the routing handler could work.